### PR TITLE
matplotlib.pylab.matrix_rank() is the MATLAB rank() equivalent.  matplot...

### DIFF
--- a/NumEx3/numex_module_3.ipynb
+++ b/NumEx3/numex_module_3.ipynb
@@ -591,13 +591,13 @@
       "\n",
       "    1. dot(E.T, E) == I\n",
       "    2. det(E) == 0\n",
-      "    3. rank(E) == 3\n",
+      "    3. matrix_rank(E) == 3\n",
       "\n",
       "If not, why?\n",
       "\n",
       "    1. dot(E.T, E) is not the identity matrix\n",
       "    2. det(E) > 0\n",
-      "    3. rank(E)> 1\n"
+      "    3. matrix_rank(E)> 1\n"
      ]
     }
    ],


### PR DESCRIPTION
...lib.pylab.rank() is equivalent to ndarray.ndim() (number of array dimensions).
